### PR TITLE
Publish artifacts to Github packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,16 +46,21 @@ subprojects {
         publications {
             mavenJava(MavenPublication) {
                 from components.java
-            }
-        }
-        repositories {
-            maven {
-                url "s3://maven.app.quickcase.s3.amazonaws.com"
-                authentication {
-                    awsIm(AwsImAuthentication)
+                pom {
+                    url.set("https://github.com/quickcase/quickcase-spring-security.git")
                 }
             }
+        }
 
+        repositories {
+            maven {
+                name = "Github"
+                url = uri("https://maven.pkg.github.com/quickcase/quickcase-spring-security")
+                credentials {
+                    username = System.getenv("GITHUB_USERNAME")
+                    password = System.getenv("GITHUB_PACKAGE_TOKEN")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Replace publishing to AWS S3 bucket by publishing to Github Packages.
This requires env vars `GITHUB_USERNAME` and `GITHUB_PACKAGE_TOKEN` to
be defined. `GITHUB_PACKAGE_TOKEN` must be an access token generated as
per https://help.github.com/en/articles/configuring-apache-maven-for-use-with-github-package-registry

Published packages are visible here: https://github.com/quickcase/quickcase-spring-security/packages/

This change has ramifications that need to be addressed:
- [x] Developer setup guidelines must be updated to include setting up these env vars to be able to pull the artefacts
- [x] Pipeline for data-store must be updated to include these env vars to be able to pull the artefacts
- [x] Pipeline for definition-store must be updated to include these env vars to be able to pull the artefact
- [ ] Pipeline for quickcase-spring-security must be setup