### PR TITLE
Allow custom profile-scope to be provided at runtime

### DIFF
--- a/api/src/main/java/app/quickcase/security/authentication/QuickcaseAuthenticationConverter.java
+++ b/api/src/main/java/app/quickcase/security/authentication/QuickcaseAuthenticationConverter.java
@@ -14,19 +14,25 @@ import static app.quickcase.security.utils.StringUtils.authorities;
 import static app.quickcase.security.utils.StringUtils.fromSpaceSeparated;
 
 public class QuickcaseAuthenticationConverter implements Converter<Jwt, QuickcaseAuthentication> {
-    private static final String SCOPE_PROFILE = "profile";
+    private static final String DEFAULT_PROFILE_SCOPE = "profile";
 
     private final UserInfoService userInfoService;
+    private String profileScope;
 
     public QuickcaseAuthenticationConverter(UserInfoService userInfoService) {
+        this(userInfoService, DEFAULT_PROFILE_SCOPE);
+    }
+
+    public QuickcaseAuthenticationConverter(UserInfoService userInfoService, String profileScope) {
         this.userInfoService = userInfoService;
+        this.profileScope = profileScope;
     }
 
     @Override
     public QuickcaseAuthentication convert(Jwt source) {
         final Set<String> scopes = fromSpaceSeparated(source.getClaimAsString("scope"));
 
-        if (scopes.contains(SCOPE_PROFILE)) {
+        if (scopes.contains(profileScope)) {
             return userAuthentication(source);
         }
 

--- a/aws-cognito/src/main/java/app/quickcase/security/QuickcaseSecurityConfig.java
+++ b/aws-cognito/src/main/java/app/quickcase/security/QuickcaseSecurityConfig.java
@@ -45,8 +45,11 @@ public class QuickcaseSecurityConfig {
     }
 
     @Bean
-    public QuickcaseAuthenticationConverter createAuthenticationConverter(UserInfoService userInfoService) {
-        return new QuickcaseAuthenticationConverter(userInfoService);
+    public QuickcaseAuthenticationConverter createAuthenticationConverter(
+            UserInfoService userInfoService,
+            @Value("${quickcase.security.oidc.profile-scope:profile}") String profileScope
+    ) {
+        return new QuickcaseAuthenticationConverter(userInfoService, profileScope);
     }
 
     @Bean

--- a/keycloak/src/main/java/app/quickcase/security/QuickcaseSecurityConfig.java
+++ b/keycloak/src/main/java/app/quickcase/security/QuickcaseSecurityConfig.java
@@ -45,8 +45,11 @@ public class QuickcaseSecurityConfig {
     }
 
     @Bean
-    public QuickcaseAuthenticationConverter createAuthenticationConverter(UserInfoService userInfoService) {
-        return new QuickcaseAuthenticationConverter(userInfoService);
+    public QuickcaseAuthenticationConverter createAuthenticationConverter(
+            UserInfoService userInfoService,
+            @Value("${quickcase.security.oidc.profile-scope:profile}") String profileScope
+    ) {
+        return new QuickcaseAuthenticationConverter(userInfoService, profileScope);
     }
 
     @Bean


### PR DESCRIPTION
Fixes #29 

- Update QuickcaseAuthenticationConverter to allow custom profile scope to be provided,
but still defaults to `profile`
- Update aws-cognito and keycloak module to read custom profile from new spring property
`quickcase.security.oidc.profile-scope` which also defaults to `profile` when not provided.