### PR TITLE
Drop `jurisdictions` claim

### DIFF
--- a/api/src/main/java/app/quickcase/spring/oidc/userinfo/UserInfo.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/userinfo/UserInfo.java
@@ -10,11 +10,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.security.Principal;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Provides QuickCase user information.
@@ -38,8 +34,6 @@ public class UserInfo implements Principal, UserDetails {
     private final String email;
     @ToString.Include
     private final Set<GrantedAuthority> authorities;
-    @ToString.Include
-    private final Set<String> jurisdictions;
     private final UserPreferences preferences;
     private final Map<String, OrganisationProfile> organisationProfiles;
 
@@ -73,9 +67,19 @@ public class UserInfo implements Principal, UserDetails {
         return true;
     }
 
+    /**
+     * @deprecated To be removed in v2.0.0, {@link #getOrganisationProfiles()} should be used instead.
+     * @return Set of organisation IDs, extracted from organisation profiles.
+     */
+    @Deprecated
+    public Set<String> getJurisdictions() {
+        return Optional.ofNullable(organisationProfiles)
+                       .map(Map::keySet)
+                       .orElse(Collections.emptySet());
+    }
+
     public static class UserInfoBuilder {
         private Set<GrantedAuthority> authorities = new HashSet<>();
-        private Set<String> jurisdictions = new HashSet<>();
         private Map<String, OrganisationProfile> organisationProfiles = new HashMap<>();
 
         public UserInfoBuilder authorities(Set<GrantedAuthority> authorities) {
@@ -87,16 +91,6 @@ public class UserInfo implements Principal, UserDetails {
             Arrays.stream(authorities)
                   .map(SimpleGrantedAuthority::new)
                   .forEach(this.authorities::add);
-            return this;
-        }
-
-        public UserInfoBuilder jurisdictions(Set<String> jurisdictions) {
-            this.jurisdictions = jurisdictions;
-            return this;
-        }
-
-        public UserInfoBuilder jurisdictions(String... jurisdictions) {
-            this.jurisdictions.addAll(Arrays.asList(jurisdictions));
             return this;
         }
 

--- a/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseAuthenticationConverterTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseAuthenticationConverterTest.java
@@ -18,11 +18,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 @DisplayName("QuickcaseAuthenticationConverter")
 class QuickcaseAuthenticationConverterTest {
@@ -33,7 +29,6 @@ class QuickcaseAuthenticationConverterTest {
     private static final String USER_ID = "user-456";
     private static final String USER_NAME = "Johnny Walker";
     private static final String USER_EMAIL = "jw@quickcase.app";
-    private static final String JURISDICTION = "juris-1";
     private static final String ROLE_1 = "role-1";
     private static final String ROLE_2 = "role-2";
 
@@ -52,7 +47,6 @@ class QuickcaseAuthenticationConverterTest {
                                                       .name(USER_NAME)
                                                       .email(USER_EMAIL)
                                                       .authorities(ROLE_1, ROLE_2)
-                                                      .jurisdictions(JURISDICTION)
                                                       .organisationProfile("org-a", orgA)
                                                       .build();
 
@@ -158,7 +152,7 @@ class QuickcaseAuthenticationConverterTest {
 
             assertThat(authentication.getUserInfo()
                                      .get()
-                                     .getJurisdictions(), contains(JURISDICTION));
+                                     .getOrganisationProfiles(), aMapWithSize(1));
         }
 
         @Test

--- a/api/src/test/java/app/quickcase/spring/oidc/userinfo/UserInfoTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/userinfo/UserInfoTest.java
@@ -1,0 +1,35 @@
+package app.quickcase.spring.oidc.userinfo;
+
+import app.quickcase.spring.oidc.organisation.OrganisationProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+
+@DisplayName("UserInfo")
+class UserInfoTest {
+
+    @Test
+    @DisplayName("should return jurisdictions from organisations for backward compatibility")
+    void shouldReturnJurisdictionBackwardCompat() {
+        final UserInfo userInfo = UserInfo.builder()
+                                          .organisationProfile("Juris-1", OrganisationProfile.builder().build())
+                                          .organisationProfile("Juris-2", OrganisationProfile.builder().build())
+                                          .build();
+
+        assertThat(userInfo.getJurisdictions(), hasItems("Juris-1", "Juris-2"));
+    }
+
+    @Test
+    @DisplayName("should return empty jurisdictions when no organisations")
+    void shouldReturnEmptyJurisdictionWhenNoOrganisations() {
+        final UserInfo userInfo = new UserInfo(null, null, null, null, null, null);
+
+        assertThat(userInfo.getJurisdictions(), equalTo(Collections.EMPTY_SET));
+    }
+
+}

--- a/implementation/src/main/java/app/quickcase/spring/oidc/DefaultClaims.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/DefaultClaims.java
@@ -5,7 +5,6 @@ public interface DefaultClaims {
     String NAME = "name";
     String EMAIL = "email";
     String APP_ROLES = "app_roles";
-    String APP_JURISDICTIONS = "jurisdictions";
     String APP_ORGANISATIONS = "app_organisations";
     String USER_DEFAULT_JURISDICTION = "default_jurisdiction";
     String USER_DEFAULT_CASE_TYPE = "default_case_type";

--- a/implementation/src/main/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractor.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractor.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Collections;
 import java.util.Map;
 
-import static app.quickcase.spring.oidc.DefaultClaims.APP_JURISDICTIONS;
 import static app.quickcase.spring.oidc.DefaultClaims.APP_ORGANISATIONS;
 import static app.quickcase.spring.oidc.DefaultClaims.APP_ROLES;
 import static app.quickcase.spring.oidc.DefaultClaims.EMAIL;
@@ -44,10 +43,6 @@ public class DefaultUserInfoExtractor implements UserInfoExtractor {
         claimsParser.getString(APP_ROLES)
                     .map(StringUtils::fromCommaSeparated)
                     .ifPresent(builder::authorities);
-
-        claimsParser.getString(APP_JURISDICTIONS)
-                    .map(string -> string.split(","))
-                    .ifPresent(builder::jurisdictions);
 
         return builder.preferences(extractPreferences(claimsParser))
                       .organisationProfiles(extractProfiles(claimsParser))

--- a/implementation/src/test/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractorTest.java
+++ b/implementation/src/test/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractorTest.java
@@ -17,7 +17,6 @@ import static app.quickcase.spring.oidc.AccessLevel.GROUP;
 import static app.quickcase.spring.oidc.AccessLevel.ORGANISATION;
 import static app.quickcase.spring.oidc.SecurityClassification.PRIVATE;
 import static app.quickcase.spring.oidc.SecurityClassification.PUBLIC;
-import static app.quickcase.spring.oidc.DefaultClaims.APP_JURISDICTIONS;
 import static app.quickcase.spring.oidc.DefaultClaims.APP_ORGANISATIONS;
 import static app.quickcase.spring.oidc.DefaultClaims.APP_ROLES;
 import static app.quickcase.spring.oidc.DefaultClaims.EMAIL;
@@ -41,7 +40,6 @@ class DefaultUserInfoExtractorTest {
     private static final String USER_ID = "eec55037-bac7-46b4-9849-f063e627e4f3";
     private static final String USER_NAME = "Test User";
     private static final String USER_EMAIL = "test@quickcase.app";
-    private static final String USER_JURISDICTIONS = "jid1,jid2";
     private static final String DEFAULT_JURISDICTION = "jid1";
     private static final String DEFAULT_CASE_TYPE = "ct1";
     private static final String DEFAULT_STATE = "stateA";
@@ -73,7 +71,7 @@ class DefaultUserInfoExtractorTest {
                         new SimpleGrantedAuthority("role2")
                 )),
                 () -> assertThat(userInfo.getJurisdictions(),
-                        containsInAnyOrder("jid1", "jid2"))
+                        containsInAnyOrder("org-1", "org-2"))
         );
     }
 
@@ -153,7 +151,6 @@ class DefaultUserInfoExtractorTest {
         claims.put(NAME, getTextNode(USER_NAME));
         claims.put(EMAIL, getTextNode(USER_EMAIL));
         claims.put(APP_ROLES, getTextNode(USER_APP_ROLES));
-        claims.put(APP_JURISDICTIONS, getTextNode(USER_JURISDICTIONS));
         claims.put(USER_DEFAULT_JURISDICTION, getTextNode(DEFAULT_JURISDICTION));
         claims.put(USER_DEFAULT_CASE_TYPE, getTextNode(DEFAULT_CASE_TYPE));
         claims.put(USER_DEFAULT_STATE, getTextNode(DEFAULT_STATE));


### PR DESCRIPTION
Fixes #36 

This legacy claim duplicates information already available in the organisation profiles.
While consumption of the claim has been entirely dropped, a deprecated `getJurisdictions()` method has been added for backward compatibility. This method returns the keys from the organisation profiles map as a set.