### PR TITLE
Add support for optional private claim prefix

### DIFF
--- a/implementation/src/main/java/app/quickcase/spring/oidc/OidcConfig.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/OidcConfig.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 
 import static app.quickcase.spring.oidc.OidcConfigDefault.Claims.*;
+import static app.quickcase.spring.oidc.OidcConfigDefault.PREFIX;
 
 /**
  * Consolidated configuration of all properties under `quickcase.oidc` namespace.
@@ -28,9 +29,19 @@ public class OidcConfig {
 
     @Value
     public static class Claims {
+        /**
+         * Prefix applied to all private claims.
+         */
+        private final String prefix;
+
+        /**
+         * Names of all claims, standard and private, used by QuickCase.
+         */
         private final ClaimNames names;
 
-        public Claims(@DefaultValue ClaimNames names) {
+        public Claims(@DefaultValue(PREFIX) String prefix,
+                      @DefaultValue ClaimNames names) {
+            this.prefix = prefix;
             this.names = names;
         }
     }

--- a/implementation/src/main/java/app/quickcase/spring/oidc/OidcConfigDefault.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/OidcConfigDefault.java
@@ -2,6 +2,7 @@ package app.quickcase.spring.oidc;
 
 public interface OidcConfigDefault {
     String NAMESPACE = "app.quickcase.claims/";
+    String PREFIX = "";
 
     interface Claims {
         // Standard claims

--- a/implementation/src/main/java/app/quickcase/spring/oidc/claims/ConfigDrivenClaimNamesProvider.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/claims/ConfigDrivenClaimNamesProvider.java
@@ -10,6 +10,7 @@ import app.quickcase.spring.oidc.OidcConfig;
  * @since 1.0
  */
 public class ConfigDrivenClaimNamesProvider implements ClaimNamesProvider {
+    private final String prefix;
     private final String sub;
     private final String name;
     private final String email;
@@ -20,6 +21,8 @@ public class ConfigDrivenClaimNamesProvider implements ClaimNamesProvider {
     private final String defaultState;
 
     public ConfigDrivenClaimNamesProvider(OidcConfig.Claims claimsConfig) {
+        this.prefix = claimsConfig.getPrefix();
+
         final OidcConfig.ClaimNames names = claimsConfig.getNames();
         this.sub = names.getSub();
         this.name = names.getName();
@@ -48,26 +51,26 @@ public class ConfigDrivenClaimNamesProvider implements ClaimNamesProvider {
 
     @Override
     public String roles() {
-        return roles;
+        return prefix + roles;
     }
 
     @Override
     public String organisations() {
-        return organisations;
+        return prefix + organisations;
     }
 
     @Override
     public String defaultJurisdiction() {
-        return defaultJurisdiction;
+        return prefix + defaultJurisdiction;
     }
 
     @Override
     public String defaultCaseType() {
-        return defaultCaseType;
+        return prefix + defaultCaseType;
     }
 
     @Override
     public String defaultState() {
-        return defaultState;
+        return prefix + defaultState;
     }
 }

--- a/implementation/src/test/java/app/quickcase/spring/oidc/OidcConfigTest.java
+++ b/implementation/src/test/java/app/quickcase/spring/oidc/OidcConfigTest.java
@@ -44,6 +44,13 @@ class OidcConfigTest {
                     () -> assertThat(names.getDefaultState(), equalTo("custom-default-state"))
             );
         }
+
+        @Test
+        @DisplayName("should provide overridden private claims prefix")
+        void shouldProvidePrivateClaimsPrefixOverride() {
+            final String prefix = oidcConfig.getClaims().getPrefix();
+            assertThat(prefix, equalTo("custom-prefix:"));
+        }
     }
 
     @Nested
@@ -69,6 +76,13 @@ class OidcConfigTest {
                     () -> assertThat(names.getDefaultCaseType(), equalTo("app.quickcase.claims/default_case_type")),
                     () -> assertThat(names.getDefaultState(), equalTo("app.quickcase.claims/default_state"))
             );
+        }
+
+        @Test
+        @DisplayName("should provide default private claims prefix")
+        void shouldProvideDefaultPrivateClaimsPrefix() {
+            final String prefix = oidcConfig.getClaims().getPrefix();
+            assertThat(prefix, equalTo(""));
         }
     }
 }

--- a/implementation/src/test/java/app/quickcase/spring/oidc/claims/ConfigDrivenClaimNamesProviderTest.java
+++ b/implementation/src/test/java/app/quickcase/spring/oidc/claims/ConfigDrivenClaimNamesProviderTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ConfigDrivenClaimNamesProviderTest {
+    private static final String PREFIX = "prefix:";
     private static final String SUB = "conf-sub";
     private static final String NAME = "conf-name";
     private static final String EMAIL = "conf-email";
@@ -29,7 +30,7 @@ class ConfigDrivenClaimNamesProviderTest {
                                                                            DEF_JURISDICTION,
                                                                            DEF_CASE_TYPE,
                                                                            DEF_STATE);
-        final OidcConfig.Claims claimsConfig = new OidcConfig.Claims(claimNames);
+        final OidcConfig.Claims claimsConfig = new OidcConfig.Claims(PREFIX, claimNames);
 
         final ConfigDrivenClaimNamesProvider claimNamesProvider = new ConfigDrivenClaimNamesProvider(claimsConfig);
 
@@ -37,11 +38,11 @@ class ConfigDrivenClaimNamesProviderTest {
                 () -> assertThat(claimNamesProvider.sub(), equalTo(SUB)),
                 () -> assertThat(claimNamesProvider.name(), equalTo(NAME)),
                 () -> assertThat(claimNamesProvider.email(), equalTo(EMAIL)),
-                () -> assertThat(claimNamesProvider.roles(), equalTo(ROLES)),
-                () -> assertThat(claimNamesProvider.organisations(), equalTo(ORGS)),
-                () -> assertThat(claimNamesProvider.defaultJurisdiction(), equalTo(DEF_JURISDICTION)),
-                () -> assertThat(claimNamesProvider.defaultCaseType(), equalTo(DEF_CASE_TYPE)),
-                () -> assertThat(claimNamesProvider.defaultState(), equalTo(DEF_STATE))
+                () -> assertThat(claimNamesProvider.roles(), equalTo(PREFIX + ROLES)),
+                () -> assertThat(claimNamesProvider.organisations(), equalTo(PREFIX + ORGS)),
+                () -> assertThat(claimNamesProvider.defaultJurisdiction(), equalTo(PREFIX + DEF_JURISDICTION)),
+                () -> assertThat(claimNamesProvider.defaultCaseType(), equalTo(PREFIX + DEF_CASE_TYPE)),
+                () -> assertThat(claimNamesProvider.defaultState(), equalTo(PREFIX + DEF_STATE))
         );
     }
 

--- a/implementation/src/test/resources/application-default.yml
+++ b/implementation/src/test/resources/application-default.yml
@@ -2,6 +2,7 @@ quickcase:
   oidc:
     user-info-uri: https://oidc.provider/userinfo
     claims:
+      prefix: 'custom-prefix:'
       names:
         sub: custom-sub
         name: custom-name


### PR DESCRIPTION
Resolves #39

Defaulting to empty string, this prefix can be used to configure a static string which should be prepended to the names of all private claims used by QuickCase.
This is useful for some provider like AWS Cognito which mandates a `custom:` prefix on all non-standard claims.