### PR TITLE
Add jwk-set-uri to quickcase config properties

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -56,7 +56,7 @@ In the `WebSecurityConfigurerAdapter`, override the `configure(HttpSecurity http
 #### 5. Add required application properties
 
 Must be configured:
-* `quickcase.security.oidc.user-info-uri`: Absolute URL to the user info endpoint exposed by the OIDC provider
-* `spring.security.oauth2.resourceserver.jwt.jwk-set-uri`: Absolute URL to the well-known JWK configuration endpoint exposed by the OIDC provider
+* `quickcase.oidc.user-info-uri`: Absolute URL to the user info endpoint exposed by the OIDC provider
+* `quickcase.oidc.jwk-set-uri`: Absolute URL to the well-known JWK configuration endpoint exposed by the OIDC provider
 
 

--- a/implementation/src/main/java/app/quickcase/spring/oidc/DefaultQuickcaseSecurityDsl.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/DefaultQuickcaseSecurityDsl.java
@@ -5,9 +5,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 
 public class DefaultQuickcaseSecurityDsl implements QuickcaseSecurityDsl {
 
+    private final OidcConfig oidcConfig;
     private final QuickcaseAuthenticationConverter authenticationConverter;
 
-    public DefaultQuickcaseSecurityDsl(QuickcaseAuthenticationConverter authenticationConverter) {
+    public DefaultQuickcaseSecurityDsl(OidcConfig oidcConfig,
+                                       QuickcaseAuthenticationConverter authenticationConverter) {
+        this.oidcConfig = oidcConfig;
         this.authenticationConverter = authenticationConverter;
     }
 
@@ -15,6 +18,7 @@ public class DefaultQuickcaseSecurityDsl implements QuickcaseSecurityDsl {
     public HttpSecurity withQuickcaseSecurity(HttpSecurity http) throws Exception {
         http.oauth2ResourceServer()
             .jwt()
+            .jwkSetUri(oidcConfig.getJwkSetUri())
             .jwtAuthenticationConverter(authenticationConverter);
         return http;
     }

--- a/implementation/src/main/java/app/quickcase/spring/oidc/OidcConfig.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/OidcConfig.java
@@ -19,10 +19,12 @@ import static app.quickcase.spring.oidc.OidcConfigDefault.PREFIX;
 @ConstructorBinding
 @ConfigurationProperties(prefix = "quickcase.oidc")
 public class OidcConfig {
+    private final String jwkSetUri;
     private final String userInfoUri;
     private final Claims claims;
 
-    public OidcConfig(String userInfoUri, @DefaultValue Claims claims) {
+    public OidcConfig(String jwkSetUri, String userInfoUri, @DefaultValue Claims claims) {
+        this.jwkSetUri = jwkSetUri;
         this.userInfoUri = userInfoUri;
         this.claims = claims;
     }

--- a/implementation/src/main/java/app/quickcase/spring/oidc/QuickcaseSecurityConfig.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/QuickcaseSecurityConfig.java
@@ -14,9 +14,9 @@ import java.net.URISyntaxException;
 
 /**
  * Configuration to import in Spring application to auto-configure Spring Security to work with a QuickCase-compliant
- * OIDC provider.
- * This configuration relies on both properties `security.oauth2.resource.jwk.key-set-uri` and
- * `security.oauth2.resource.user-info-uri` being defined in Spring application.
+ * OIDC providers.
+ * This configuration relies on both properties `quickcase.oidc.jwk-set-uri` and `quickcase.oidc.user-info-uri`
+ * being defined as properties in the Spring application.
  *
  * @author Valentin Laurin
  * @since 0.1
@@ -52,7 +52,8 @@ public class QuickcaseSecurityConfig {
     }
 
     @Bean
-    public QuickcaseSecurityDsl createSecurityDsl(QuickcaseAuthenticationConverter authenticationConverter) {
-        return new DefaultQuickcaseSecurityDsl(authenticationConverter);
+    public QuickcaseSecurityDsl createSecurityDsl(OidcConfig oidcConfig,
+                                                  QuickcaseAuthenticationConverter authenticationConverter) {
+        return new DefaultQuickcaseSecurityDsl(oidcConfig, authenticationConverter);
     }
 }

--- a/implementation/src/test/java/app/quickcase/spring/oidc/OidcConfigTest.java
+++ b/implementation/src/test/java/app/quickcase/spring/oidc/OidcConfigTest.java
@@ -26,6 +26,7 @@ class OidcConfigTest {
         @Test
         @DisplayName("should provide user-info-uri")
         void shouldProvideRootConfiguration() {
+            assertThat(oidcConfig.getJwkSetUri(), equalTo("https://oidc.provider/jwkset"));
             assertThat(oidcConfig.getUserInfoUri(), equalTo("https://oidc.provider/userinfo"));
         }
 

--- a/implementation/src/test/resources/application-default.yml
+++ b/implementation/src/test/resources/application-default.yml
@@ -1,5 +1,6 @@
 quickcase:
   oidc:
+    jwk-set-uri: https://oidc.provider/jwkset
     user-info-uri: https://oidc.provider/userinfo
     claims:
       prefix: 'custom-prefix:'

--- a/implementation/src/test/resources/application-partial.yml
+++ b/implementation/src/test/resources/application-partial.yml
@@ -1,3 +1,4 @@
 quickcase:
   oidc:
+    jwk-set-uri: https://oidc.provider/jwkset
     user-info-uri: https://oidc.provider/userinfo


### PR DESCRIPTION
Resolves #35 

Instead of relying on Spring's native property (spring.security.oauth2.resourceserver.jwt.jwk-set-uri),
accept jwk-set-uri as a custom quickcase property. This is to consolidate all required configuration
under a single umbrella and abstract the underlying implementation.