### PR TITLE
Suppress CVE-2021-22112

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -10,4 +10,14 @@
         ]]></notes>
         <cve>CVE-2018-1258</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+            file name: spring-boot-starter-oauth2-resource-server-*.jar
+
+            This suppresses a false-positive identifying spring-boot-starter-oauth2-resource-server-2.6.3.jar as Spring Security 2.6.3,
+            whereas the version of Spring Security used is actually 5.6.1 which is not affected by CVE-2021-22112.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot\-starter\-oauth2\-resource\-server@.*$</packageUrl>
+        <cve>CVE-2021-22112</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
This suppresses a false-positive identifying spring-boot-starter-oauth2-resource-server-2.6.3.jar as Spring Security 2.6.3,
whereas the version of Spring Security used is actually 5.6.1 which is not affected by CVE-2021-22112.