### PR TITLE
Add claim `app.quickcase.claims/groups`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ QuickCase relies on each users having private claims exposed through OpenID Conn
 
 Required, String. Comma-separated list of user roles used by QuickCase to enforce role-based ACLs.
 
+#### app.quickcase.claims/groups
+
+Optional, String. Comma-separated list of groups the user is a member of, relevant when the user access level is `GROUP`.
+Mutually exclusive with claim `app.quickcase.claims/organisations`, this claim should only be used when role-driven authorisation is used. 
+
 #### app.quickcase.claims/organisations
 
 Required, JSON String. JSON object containing the one or many organisations a user is granted access to. For each organisation are defined:
@@ -83,18 +88,19 @@ By default, the decision to fetch `/userinfo` is controlled by the presence of t
 
 ### Configuration
 
-|Config|Default|Description|
-|---|---|---|
-|quickcase.oidc.mode <br> _QUICKCASE_OIDC_MODE_|`user-info`|Optional. Mode to use for integration with OIDC provider|
-|quickcase.oidc.jwk-set-uri <br> _QUICKCASE_OIDC_JWKSETURI_||Required. URL of the OIDC provider's JWK set endpoint|
-|quickcase.oidc.user-info-uri <br> _QUICKCASE_OIDC_USERINFOURI_||Required. URL of the OIDC provider's user info endpoint|
-|quickcase.oidc.openid-scope <br> _QUICKCASE_OIDC_OPENIDSCOPE_|`openid`|Optional. Scope controlling whether `/userinfo` is queried to extract ID claims|
-|quickcase.oidc.claims.prefix <br> _QUICKCASE_OIDC_CLAIMS_PREFIX_|empty string|Optional. Prefix to apply to all private claims|
-|quickcase.oidc.claims.names.sub <br> _QUICKCASE_OIDC_CLAIMS_NAMES_SUB_|`sub`|Optional. Override name of OpenID `sub` claim from which subject is extracted|
-|quickcase.oidc.claims.names.name <br> _QUICKCASE_OIDC_CLAIMS_NAMES_NAME_|`name`|Optional. Override name of OpenID `name` claim from which subject name is extracted|
-|quickcase.oidc.claims.names.email <br> _QUICKCASE_OIDC_CLAIMS_NAMES_EMAIL_|`email`|Optional. Override name of OpenID `email` claim from which subject email is extracted|
-|quickcase.oidc.claims.names.roles <br> _QUICKCASE_OIDC_CLAIMS_NAMES_ROLES_|`app.quickcase.claims/roles`|Optional. Override name of private roles claim from which subject's QuickCase roles are extracted|
-|quickcase.oidc.claims.names.organisations <br> _QUICKCASE_OIDC_CLAIMS_NAMES_ORGANISATIONS_|`app.quickcase.claims/organisations`|Optional. Override name of private organisations claim from which subject's QuickCase organisation profiles are extracted|
-|quickcase.oidc.claims.names.default-jurisdiction <br> _QUICKCASE_OIDC_CLAIMS_NAMES_DEFAULTJURISDICTION_|`app.quickcase.claims/default_jurisdiction` |Optional. Override name of private default jurisdiction claim from which subject's QuickCase UI preference is extracted|
-|quickcase.oidc.claims.names.default-case-type <br> _QUICKCASE_OIDC_CLAIMS_NAMES_DEFAULTCASETYPE_|`app.quickcase.claims/default_case_type` |Optional. Override name of private default case type claim from which subject's QuickCase UI preference is extracted|
-|quickcase.oidc.claims.names.default-state <br> _QUICKCASE_OIDC_CLAIMS_NAMES_DEFAULTSTATE_|`app.quickcase.claims/default_state` |Optional. Override name of private default state claim from which subject's QuickCase UI preference is extracted|
+| Config                                                                                                  | Default                                     | Description                                                                                                               |
+|---------------------------------------------------------------------------------------------------------|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| quickcase.oidc.mode <br> _QUICKCASE_OIDC_MODE_                                                          | `user-info`                                 | Optional. Mode to use for integration with OIDC provider                                                                  |
+| quickcase.oidc.jwk-set-uri <br> _QUICKCASE_OIDC_JWKSETURI_                                              |                                             | Required. URL of the OIDC provider's JWK set endpoint                                                                     |
+| quickcase.oidc.user-info-uri <br> _QUICKCASE_OIDC_USERINFOURI_                                          |                                             | Required. URL of the OIDC provider's user info endpoint                                                                   |
+| quickcase.oidc.openid-scope <br> _QUICKCASE_OIDC_OPENIDSCOPE_                                           | `openid`                                    | Optional. Scope controlling whether `/userinfo` is queried to extract ID claims                                           |
+| quickcase.oidc.claims.prefix <br> _QUICKCASE_OIDC_CLAIMS_PREFIX_                                        | empty string                                | Optional. Prefix to apply to all private claims                                                                           |
+| quickcase.oidc.claims.names.sub <br> _QUICKCASE_OIDC_CLAIMS_NAMES_SUB_                                  | `sub`                                       | Optional. Override name of OpenID `sub` claim from which subject is extracted                                             |
+| quickcase.oidc.claims.names.name <br> _QUICKCASE_OIDC_CLAIMS_NAMES_NAME_                                | `name`                                      | Optional. Override name of OpenID `name` claim from which subject name is extracted                                       |
+| quickcase.oidc.claims.names.email <br> _QUICKCASE_OIDC_CLAIMS_NAMES_EMAIL_                              | `email`                                     | Optional. Override name of OpenID `email` claim from which subject email is extracted                                     |
+| quickcase.oidc.claims.names.roles <br> _QUICKCASE_OIDC_CLAIMS_NAMES_ROLES_                              | `app.quickcase.claims/roles`                | Optional. Override name of private roles claim from which subject's QuickCase roles are extracted                         |
+| quickcase.oidc.claims.names.groups <br> _QUICKCASE_OIDC_CLAIMS_NAMES_GROUPS_                            | `app.quickcase.claims/groups`               | Optional. Override name of private groups claim from which subject's QuickCase groups are extracted                       |
+| quickcase.oidc.claims.names.organisations <br> _QUICKCASE_OIDC_CLAIMS_NAMES_ORGANISATIONS_              | `app.quickcase.claims/organisations`        | Optional. Override name of private organisations claim from which subject's QuickCase organisation profiles are extracted |
+| quickcase.oidc.claims.names.default-jurisdiction <br> _QUICKCASE_OIDC_CLAIMS_NAMES_DEFAULTJURISDICTION_ | `app.quickcase.claims/default_jurisdiction` | Optional. Override name of private default jurisdiction claim from which subject's QuickCase UI preference is extracted   |
+| quickcase.oidc.claims.names.default-case-type <br> _QUICKCASE_OIDC_CLAIMS_NAMES_DEFAULTCASETYPE_        | `app.quickcase.claims/default_case_type`    | Optional. Override name of private default case type claim from which subject's QuickCase UI preference is extracted      |
+| quickcase.oidc.claims.names.default-state <br> _QUICKCASE_OIDC_CLAIMS_NAMES_DEFAULTSTATE_               | `app.quickcase.claims/default_state`        | Optional. Override name of private default state claim from which subject's QuickCase UI preference is extracted          |

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseAuthentication.java
@@ -1,12 +1,13 @@
 package app.quickcase.spring.oidc.authentication;
 
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
 import app.quickcase.spring.oidc.organisation.OrganisationProfile;
 import app.quickcase.spring.oidc.userinfo.UserInfo;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
-
-import java.util.Collection;
-import java.util.Optional;
 
 /**
  * QuickCase-flavoured authentication. This aims at providing a best-effort in consistency
@@ -36,6 +37,8 @@ public abstract class QuickcaseAuthentication extends AbstractAuthenticationToke
     public abstract Optional<String> getEmail();
 
     public abstract String getId();
+
+    public abstract Set<String> getGroups();
 
     public abstract OrganisationProfile getOrganisationProfile(String organisationId);
 

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthentication.java
@@ -1,13 +1,14 @@
 package app.quickcase.spring.oidc.authentication;
 
-import app.quickcase.spring.oidc.AccessLevel;
-import app.quickcase.spring.oidc.organisation.OrganisationProfile;
-import app.quickcase.spring.oidc.SecurityClassification;
-import app.quickcase.spring.oidc.userinfo.UserInfo;
-import org.springframework.security.core.GrantedAuthority;
-
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
+
+import app.quickcase.spring.oidc.AccessLevel;
+import app.quickcase.spring.oidc.SecurityClassification;
+import app.quickcase.spring.oidc.organisation.OrganisationProfile;
+import app.quickcase.spring.oidc.userinfo.UserInfo;
+import org.springframework.security.core.GrantedAuthority;
 
 public class QuickcaseClientAuthentication extends QuickcaseAuthentication {
     private static final String DEFAULT_NAME = "System";
@@ -48,6 +49,11 @@ public class QuickcaseClientAuthentication extends QuickcaseAuthentication {
     @Override
     public String getName() {
         return DEFAULT_NAME;
+    }
+
+    @Override
+    public Set<String> getGroups() {
+        return Set.of();
     }
 
     @Override

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthentication.java
@@ -1,13 +1,14 @@
 package app.quickcase.spring.oidc.authentication;
 
+import java.util.Optional;
+import java.util.Set;
+
 import app.quickcase.spring.oidc.AccessLevel;
 import app.quickcase.spring.oidc.SecurityClassification;
 import app.quickcase.spring.oidc.organisation.OrganisationProfile;
 import app.quickcase.spring.oidc.userinfo.UserInfo;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.Optional;
 
 @Slf4j
 public class QuickcaseUserAuthentication extends QuickcaseAuthentication {
@@ -45,6 +46,11 @@ public class QuickcaseUserAuthentication extends QuickcaseAuthentication {
     @Override
     public String getName() {
         return userInfo.getName();
+    }
+
+    @Override
+    public Set<String> getGroups() {
+        return userInfo.getGroups();
     }
 
     @Override

--- a/api/src/main/java/app/quickcase/spring/oidc/claims/ClaimNamesProvider.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/claims/ClaimNamesProvider.java
@@ -20,6 +20,7 @@ public interface ClaimNamesProvider {
     }
 
     String roles();
+    String groups();
     String organisations();
     String defaultJurisdiction();
     String defaultCaseType();

--- a/api/src/main/java/app/quickcase/spring/oidc/userinfo/UserInfo.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/userinfo/UserInfo.java
@@ -1,14 +1,25 @@
 package app.quickcase.spring.oidc.userinfo;
 
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+
 import app.quickcase.spring.oidc.UserAuthenticationToken;
 import app.quickcase.spring.oidc.organisation.OrganisationProfile;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.Value;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import java.security.Principal;
-import java.util.*;
 
 /**
  * Provides QuickCase user information.
@@ -34,6 +45,9 @@ public class UserInfo implements Principal, UserDetails {
     @NonNull
     @ToString.Include
     private final Set<GrantedAuthority> authorities;
+    @NonNull
+    @ToString.Include
+    private final Set<String> groups;
     private final UserPreferences preferences;
     @NonNull
     private final Map<String, OrganisationProfile> organisationProfiles;
@@ -97,6 +111,7 @@ public class UserInfo implements Principal, UserDetails {
         private String name;
         private String email;
         private Set<GrantedAuthority> authorities = new HashSet<>();
+        private Set<String> groups = new HashSet<>();
         private UserPreferences preferences;
         private final Map<String, OrganisationProfile> organisationProfiles = new TreeMap<>(String::compareToIgnoreCase);
 
@@ -122,6 +137,16 @@ public class UserInfo implements Principal, UserDetails {
             return this;
         }
 
+        public UserInfoBuilder groups(Set<String> groups) {
+            this.groups.addAll(groups);
+            return this;
+        }
+
+        public UserInfoBuilder groups(String... groups) {
+            this.groups.addAll(Arrays.asList(groups));
+            return this;
+        }
+
         public UserInfoBuilder preferences(UserPreferences preferences) {
             this.preferences = preferences;
             return this;
@@ -138,7 +163,7 @@ public class UserInfo implements Principal, UserDetails {
         }
 
         public UserInfo build() {
-            return new UserInfo(subject, name, email, authorities, preferences, organisationProfiles);
+            return new UserInfo(subject, name, email, authorities, groups, preferences, organisationProfiles);
         }
     }
 }

--- a/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthenticationTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthenticationTest.java
@@ -1,19 +1,18 @@
 package app.quickcase.spring.oidc.authentication;
 
+import java.util.Set;
+
 import app.quickcase.spring.oidc.AccessLevel;
-import app.quickcase.spring.oidc.organisation.OrganisationProfile;
 import app.quickcase.spring.oidc.SecurityClassification;
+import app.quickcase.spring.oidc.organisation.OrganisationProfile;
 import app.quickcase.spring.oidc.utils.StringUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.GrantedAuthority;
 
-import java.util.Set;
-
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class QuickcaseClientAuthenticationTest {
@@ -32,6 +31,13 @@ class QuickcaseClientAuthenticationTest {
     void getId() {
         final QuickcaseAuthentication auth = clientAuthentication();
         assertThat(auth.getId(), equalTo(CLIENT_ID));
+    }
+
+    @Test
+    @DisplayName("should not have groups")
+    void getGroups() {
+        final QuickcaseAuthentication auth = clientAuthentication();
+        assertThat(auth.getGroups(), is(emptyCollectionOf(String.class)));
     }
 
     @Test

--- a/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthenticationTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthenticationTest.java
@@ -12,8 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -104,6 +103,13 @@ class QuickcaseUserAuthenticationTest {
     }
 
     @Test
+    @DisplayName("should have groups")
+    void getGroups() {
+        final QuickcaseAuthentication auth = userAuthentication();
+        assertThat(auth.getGroups(), containsInAnyOrder("group1", "group2"));
+    }
+
+    @Test
     @DisplayName("should give default organisation profile when org not found")
     void getOrganisationProfileWhenNotFound() {
         final QuickcaseAuthentication auth = userAuthentication();
@@ -141,6 +147,7 @@ class QuickcaseUserAuthenticationTest {
                                           .name(USER_NAME)
                                           .email(USER_EMAIL)
                                           .authorities("ROLE-1", "ROLE-2")
+                                          .groups("group1", "group2")
                                           .organisationProfile("org-1", profile)
                                           .build();
 

--- a/implementation/src/main/java/app/quickcase/spring/oidc/OidcConfig.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/OidcConfig.java
@@ -62,6 +62,7 @@ public class OidcConfig {
         private final String name;
         private final String email;
         private final String roles;
+        private final String groups;
         private final String organisations;
         private final String defaultJurisdiction;
         private final String defaultCaseType;
@@ -71,6 +72,7 @@ public class OidcConfig {
                           @DefaultValue(NAME) String name,
                           @DefaultValue(EMAIL) String email,
                           @DefaultValue(QC_ROLES) String roles,
+                          @DefaultValue(QC_GROUPS) String groups,
                           @DefaultValue(QC_ORGANISATIONS) String organisations,
                           @DefaultValue(QC_USER_DEFAULT_JURISDICTION) String defaultJurisdiction,
                           @DefaultValue(QC_USER_DEFAULT_CASE_TYPE) String defaultCaseType,
@@ -79,6 +81,7 @@ public class OidcConfig {
             this.name = name;
             this.email = email;
             this.roles = roles;
+            this.groups = groups;
             this.organisations = organisations;
             this.defaultJurisdiction = defaultJurisdiction;
             this.defaultCaseType = defaultCaseType;

--- a/implementation/src/main/java/app/quickcase/spring/oidc/OidcConfigDefault.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/OidcConfigDefault.java
@@ -11,6 +11,7 @@ public interface OidcConfigDefault {
         String EMAIL = "email";
         // Private claims
         String QC_ROLES = NAMESPACE + "roles";
+        String QC_GROUPS = NAMESPACE + "groups";
         String QC_ORGANISATIONS = NAMESPACE + "organisations";
         String QC_USER_DEFAULT_JURISDICTION = NAMESPACE + "default_jurisdiction";
         String QC_USER_DEFAULT_CASE_TYPE = NAMESPACE + "default_case_type";

--- a/implementation/src/main/java/app/quickcase/spring/oidc/claims/ConfigDrivenClaimNamesProvider.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/claims/ConfigDrivenClaimNamesProvider.java
@@ -15,6 +15,7 @@ public class ConfigDrivenClaimNamesProvider implements ClaimNamesProvider {
     private final String name;
     private final String email;
     private final String roles;
+    private final String groups;
     private final String organisations;
     private final String defaultJurisdiction;
     private final String defaultCaseType;
@@ -28,6 +29,7 @@ public class ConfigDrivenClaimNamesProvider implements ClaimNamesProvider {
         this.name = names.getName();
         this.email = names.getEmail();
         this.roles = names.getRoles();
+        this.groups = names.getGroups();
         this.organisations = names.getOrganisations();
         this.defaultJurisdiction = names.getDefaultJurisdiction();
         this.defaultCaseType = names.getDefaultCaseType();
@@ -52,6 +54,11 @@ public class ConfigDrivenClaimNamesProvider implements ClaimNamesProvider {
     @Override
     public String roles() {
         return prefix + roles;
+    }
+
+    @Override
+    public String groups() {
+        return prefix + groups;
     }
 
     @Override

--- a/implementation/src/main/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractor.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractor.java
@@ -9,7 +9,6 @@ import app.quickcase.spring.oidc.claims.ClaimsParser;
 import app.quickcase.spring.oidc.organisation.JsonOrganisationProfilesParser;
 import app.quickcase.spring.oidc.organisation.OrganisationProfile;
 import app.quickcase.spring.oidc.utils.StringUtils;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -35,6 +34,10 @@ public class DefaultUserInfoExtractor implements UserInfoExtractor {
         claimsParser.getString(claimNames.roles())
                     .map(StringUtils::fromCommaSeparated)
                     .ifPresent(builder::authorities);
+
+        claimsParser.getString(claimNames.groups())
+                    .map((str) -> StringUtils.fromString(str, ","))
+                    .ifPresent(builder::groups);
 
         return builder.preferences(extractPreferences(claimsParser))
                       .organisationProfiles(extractProfiles(subject, claimsParser))

--- a/implementation/src/test/java/app/quickcase/spring/oidc/claims/ConfigDrivenClaimNamesProviderTest.java
+++ b/implementation/src/test/java/app/quickcase/spring/oidc/claims/ConfigDrivenClaimNamesProviderTest.java
@@ -14,6 +14,7 @@ class ConfigDrivenClaimNamesProviderTest {
     private static final String NAME = "conf-name";
     private static final String EMAIL = "conf-email";
     private static final String ROLES = "conf-roles";
+    private static final String GROUPS = "conf-groups";
     private static final String ORGS = "conf-orgs";
     private static final String DEF_JURISDICTION = "conf-jurisdiction";
     private static final String DEF_CASE_TYPE = "conf-case-type";
@@ -26,19 +27,21 @@ class ConfigDrivenClaimNamesProviderTest {
                                                                            NAME,
                                                                            EMAIL,
                                                                            ROLES,
+                                                                           GROUPS,
                                                                            ORGS,
                                                                            DEF_JURISDICTION,
                                                                            DEF_CASE_TYPE,
                                                                            DEF_STATE);
         final OidcConfig.Claims claimsConfig = new OidcConfig.Claims(PREFIX, claimNames);
 
-        final ConfigDrivenClaimNamesProvider claimNamesProvider = new ConfigDrivenClaimNamesProvider(claimsConfig);
+        final ClaimNamesProvider claimNamesProvider = new ConfigDrivenClaimNamesProvider(claimsConfig);
 
         assertAll(
                 () -> assertThat(claimNamesProvider.sub(), equalTo(SUB)),
                 () -> assertThat(claimNamesProvider.name(), equalTo(NAME)),
                 () -> assertThat(claimNamesProvider.email(), equalTo(EMAIL)),
                 () -> assertThat(claimNamesProvider.roles(), equalTo(PREFIX + ROLES)),
+                () -> assertThat(claimNamesProvider.groups(), equalTo(PREFIX + GROUPS)),
                 () -> assertThat(claimNamesProvider.organisations(), equalTo(PREFIX + ORGS)),
                 () -> assertThat(claimNamesProvider.defaultJurisdiction(), equalTo(PREFIX + DEF_JURISDICTION)),
                 () -> assertThat(claimNamesProvider.defaultCaseType(), equalTo(PREFIX + DEF_CASE_TYPE)),

--- a/implementation/src/test/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractorTest.java
+++ b/implementation/src/test/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractorTest.java
@@ -32,12 +32,14 @@ class DefaultUserInfoExtractorTest {
     private static final String CLAIM_NAME = "conf-name";
     private static final String CLAIM_EMAIL = "conf-email";
     private static final String CLAIM_ROLES = "conf-roles";
+    private static final String CLAIM_GROUPS = "conf-groups";
     private static final String CLAIM_ORGS = "conf-orgs";
     private static final String CLAIM_DEF_JURISDICTION = "conf-jurisdiction";
     private static final String CLAIM_DEF_CASE_TYPE = "conf-case-type";
     private static final String CLAIM_DEF_STATE = "conf-state";
 
     private static final String USER_APP_ROLES = "role1,role2";
+    private static final String USER_GROUPS = "group1,group2";
     private static final String USER_ID = "eec55037-bac7-46b4-9849-f063e627e4f3";
     private static final String USER_NAME = "Test User";
     private static final String USER_EMAIL = "test@quickcase.app";
@@ -63,6 +65,7 @@ class DefaultUserInfoExtractorTest {
                         new SimpleGrantedAuthority("role1"),
                         new SimpleGrantedAuthority("role2")
                 )),
+                () -> assertThat(userInfo.getGroups(), containsInAnyOrder("group1", "group2")),
                 () -> assertThat(userInfo.getJurisdictions(),
                         containsInAnyOrder("org-1", "org-2"))
         );
@@ -133,6 +136,7 @@ class DefaultUserInfoExtractorTest {
         claims.put(CLAIM_NAME, textNode(USER_NAME));
         claims.put(CLAIM_EMAIL, textNode(USER_EMAIL));
         claims.put(CLAIM_ROLES, textNode(USER_APP_ROLES));
+        claims.put(CLAIM_GROUPS, textNode(USER_GROUPS));
         claims.put(CLAIM_ORGS, textNode(USER_ORGANISATIONS));
         claims.put(CLAIM_DEF_JURISDICTION, textNode(DEFAULT_JURISDICTION));
         claims.put(CLAIM_DEF_CASE_TYPE, textNode(DEFAULT_CASE_TYPE));
@@ -170,6 +174,11 @@ class DefaultUserInfoExtractorTest {
             @Override
             public String roles() {
                 return CLAIM_ROLES;
+            }
+
+            @Override
+            public String groups() {
+                return CLAIM_GROUPS;
             }
 
             @Override


### PR DESCRIPTION
In the new role-driven authorisation mode, organisation profiles are not used anymore and a new top-level claim is required to capture groups instead.