### PR TITLE
Separate roles from authorities

### DIFF
--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseAuthentication.java
@@ -38,6 +38,8 @@ public abstract class QuickcaseAuthentication extends AbstractAuthenticationToke
 
     public abstract String getId();
 
+    public abstract Set<String> getRoles();
+
     public abstract Set<String> getGroups();
 
     public abstract OrganisationProfile getOrganisationProfile(String organisationId);

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthentication.java
@@ -3,6 +3,7 @@ package app.quickcase.spring.oidc.authentication;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import app.quickcase.spring.oidc.AccessLevel;
 import app.quickcase.spring.oidc.SecurityClassification;
@@ -49,6 +50,13 @@ public class QuickcaseClientAuthentication extends QuickcaseAuthentication {
     @Override
     public String getName() {
         return DEFAULT_NAME;
+    }
+
+    @Override
+    public Set<String> getRoles() {
+        return getAuthorities().stream()
+                               .map(GrantedAuthority::getAuthority)
+                               .collect(Collectors.toSet());
     }
 
     @Override

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthentication.java
@@ -9,6 +9,7 @@ import app.quickcase.spring.oidc.organisation.OrganisationProfile;
 import app.quickcase.spring.oidc.userinfo.UserInfo;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
 
 @Slf4j
 public class QuickcaseUserAuthentication extends QuickcaseAuthentication {
@@ -22,8 +23,8 @@ public class QuickcaseUserAuthentication extends QuickcaseAuthentication {
 
     private final UserInfo userInfo;
 
-    public QuickcaseUserAuthentication(@NonNull String accessToken, @NonNull UserInfo userInfo) {
-        super(userInfo.getAuthorities(), accessToken);
+    public QuickcaseUserAuthentication(@NonNull String accessToken, @NonNull Set<GrantedAuthority> authorities, @NonNull UserInfo userInfo) {
+        super(authorities, accessToken);
         this.userInfo = userInfo;
         this.setAuthenticated(true);
     }

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthentication.java
@@ -49,6 +49,11 @@ public class QuickcaseUserAuthentication extends QuickcaseAuthentication {
     }
 
     @Override
+    public Set<String> getRoles() {
+        return userInfo.getRoles();
+    }
+
+    @Override
     public Set<String> getGroups() {
         return userInfo.getGroups();
     }

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/converter/AccessTokenAuthenticationConverter.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/converter/AccessTokenAuthenticationConverter.java
@@ -53,6 +53,7 @@ public class AccessTokenAuthenticationConverter implements QuickcaseAuthenticati
 
     private QuickcaseAuthentication userAuthentication(Jwt source) {
         final ClaimsParser claims = new JwtClaimsParser(source.getClaims());
-        return new QuickcaseUserAuthentication(source.getTokenValue(), userInfoExtractor.extract(claims));
+        final Set<String> scopes = fromSpaceSeparated(source.getClaimAsString("scope"));
+        return new QuickcaseUserAuthentication(source.getTokenValue(), authorities(scopes), userInfoExtractor.extract(claims));
     }
 }

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/converter/UserInfoAuthenticationConverter.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/converter/UserInfoAuthenticationConverter.java
@@ -49,8 +49,9 @@ public class UserInfoAuthenticationConverter implements QuickcaseAuthenticationC
     private QuickcaseUserAuthentication userAuthentication(Jwt source) {
         final String subject = source.getSubject();
         final String accessToken = source.getTokenValue();
+        final Set<String> scopes = fromSpaceSeparated(source.getClaimAsString("scope"));
         final UserInfo userInfo = userInfoService.loadUserInfo(subject, accessToken);
 
-        return new QuickcaseUserAuthentication(accessToken, userInfo);
+        return new QuickcaseUserAuthentication(accessToken, authorities(scopes), userInfo);
     }
 }

--- a/api/src/main/java/app/quickcase/spring/oidc/userinfo/UserInfo.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/userinfo/UserInfo.java
@@ -47,6 +47,9 @@ public class UserInfo implements Principal, UserDetails {
     private final Set<GrantedAuthority> authorities;
     @NonNull
     @ToString.Include
+    private final Set<String> roles;
+    @NonNull
+    @ToString.Include
     private final Set<String> groups;
     private final UserPreferences preferences;
     @NonNull
@@ -111,6 +114,7 @@ public class UserInfo implements Principal, UserDetails {
         private String name;
         private String email;
         private Set<GrantedAuthority> authorities = new HashSet<>();
+        private Set<String> roles = new HashSet<>();
         private Set<String> groups = new HashSet<>();
         private UserPreferences preferences;
         private final Map<String, OrganisationProfile> organisationProfiles = new TreeMap<>(String::compareToIgnoreCase);
@@ -134,6 +138,16 @@ public class UserInfo implements Principal, UserDetails {
             Arrays.stream(authorities)
                   .map(SimpleGrantedAuthority::new)
                   .forEach(this.authorities::add);
+            return this;
+        }
+
+        public UserInfoBuilder roles(Set<String> roles) {
+            this.roles.addAll(roles);
+            return this;
+        }
+
+        public UserInfoBuilder roles(String... roles) {
+            this.roles.addAll(Arrays.asList(roles));
             return this;
         }
 
@@ -163,7 +177,7 @@ public class UserInfo implements Principal, UserDetails {
         }
 
         public UserInfo build() {
-            return new UserInfo(subject, name, email, authorities, groups, preferences, organisationProfiles);
+            return new UserInfo(subject, name, email, authorities, roles, groups, preferences, organisationProfiles);
         }
     }
 }

--- a/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthenticationTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthenticationTest.java
@@ -34,6 +34,13 @@ class QuickcaseClientAuthenticationTest {
     }
 
     @Test
+    @DisplayName("should expose authorities as roles")
+    void getRoles() {
+        final QuickcaseAuthentication auth = clientAuthentication();
+        assertThat(auth.getRoles(), containsInAnyOrder("ROLE-1", "ROLE-2"));
+    }
+
+    @Test
     @DisplayName("should not have groups")
     void getGroups() {
         final QuickcaseAuthentication auth = clientAuthentication();

--- a/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthenticationTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthenticationTest.java
@@ -103,6 +103,13 @@ class QuickcaseUserAuthenticationTest {
     }
 
     @Test
+    @DisplayName("should have roles")
+    void getRoles() {
+        final QuickcaseAuthentication auth = userAuthentication();
+        assertThat(auth.getRoles(), containsInAnyOrder("role1", "role2"));
+    }
+
+    @Test
     @DisplayName("should have groups")
     void getGroups() {
         final QuickcaseAuthentication auth = userAuthentication();
@@ -147,6 +154,7 @@ class QuickcaseUserAuthenticationTest {
                                           .name(USER_NAME)
                                           .email(USER_EMAIL)
                                           .authorities("ROLE-1", "ROLE-2")
+                                          .roles("role1", "role2")
                                           .groups("group1", "group2")
                                           .organisationProfile("org-1", profile)
                                           .build();

--- a/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthenticationTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthenticationTest.java
@@ -8,8 +8,11 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -26,8 +29,9 @@ class QuickcaseUserAuthenticationTest {
     @DisplayName("should enforce non-null fields")
     void shouldEnforceNonNullFields() {
         Assertions.assertAll(
-                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(null, UserInfo.builder(USER_ID).build())),
-                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(ACCESS_TOKEN, null))
+                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(null, Set.of(), UserInfo.builder(USER_ID).build())),
+                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(ACCESS_TOKEN, null, UserInfo.builder(USER_ID).build())),
+                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(ACCESS_TOKEN, Set.of(), null))
         );
     }
 
@@ -89,6 +93,16 @@ class QuickcaseUserAuthenticationTest {
     }
 
     @Test
+    @DisplayName("should have authorities")
+    void getAuthorities() {
+        final QuickcaseAuthentication auth = userAuthentication();
+        assertThat(auth.getAuthorities(), containsInAnyOrder(
+                new SimpleGrantedAuthority("SCOPE-1"),
+                new SimpleGrantedAuthority("SCOPE-2")
+        ));
+    }
+
+    @Test
     @DisplayName("should use user name")
     void getName() {
         final QuickcaseAuthentication auth = userAuthentication();
@@ -145,6 +159,11 @@ class QuickcaseUserAuthenticationTest {
     }
 
     private QuickcaseAuthentication userAuthentication() {
+        final Set<GrantedAuthority> authorities = Set.of(
+                new SimpleGrantedAuthority("SCOPE-1"),
+                new SimpleGrantedAuthority("SCOPE-2")
+        );
+
         final OrganisationProfile profile = OrganisationProfile.builder()
                                                                .accessLevel(AccessLevel.GROUP)
                                                                .group("org-1-group")
@@ -159,6 +178,6 @@ class QuickcaseUserAuthenticationTest {
                                           .organisationProfile("org-1", profile)
                                           .build();
 
-        return new QuickcaseUserAuthentication(ACCESS_TOKEN, userInfo);
+        return new QuickcaseUserAuthentication(ACCESS_TOKEN, authorities, userInfo);
     }
 }

--- a/api/src/test/java/app/quickcase/spring/oidc/authentication/converter/AccessTokenAuthenticationConverterTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/authentication/converter/AccessTokenAuthenticationConverterTest.java
@@ -52,6 +52,7 @@ class AccessTokenAuthenticationConverterTest {
                     .name(claimsParser.getString("name").orElseThrow())
                     .email(claimsParser.getString("email").orElseThrow())
                     .authorities(authorities)
+                    .roles(ROLE_1, ROLE_2)
                     .preferences(preferences)
                     .build();
         };
@@ -140,11 +141,11 @@ class AccessTokenAuthenticationConverterTest {
             assertThat(authentication.getId(), equalTo(USER_ID));
             assertThat(authentication.getName(), equalTo(USER_NAME));
             assertThat(authentication.getEmail().get(), equalTo(USER_EMAIL));
+            assertThat(authentication.getAuthorities(), containsInAnyOrder(authorities(AccessTokenAuthenticationConverter.OPENID_SCOPE, SCOPE_2)));
+            assertThat(authentication.getRoles(), containsInAnyOrder(ROLE_1, ROLE_2));
             assertThat(authentication.getUserInfo()
                                      .get()
                                      .getPreferences().getDefaultJurisdiction(), equalTo(DEFAULT_JURISDICTION));
-            final GrantedAuthority[] roles = authorities(ROLE_1, ROLE_2);
-            assertThat(authentication.getAuthorities(), containsInAnyOrder(roles));
         }
 
         @Test

--- a/api/src/test/java/app/quickcase/spring/oidc/authentication/converter/UserInfoAuthenticationConverterTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/authentication/converter/UserInfoAuthenticationConverterTest.java
@@ -158,12 +158,11 @@ class UserInfoAuthenticationConverterTest {
         }
 
         @Test
-        @DisplayName("should use user roles as authorities")
+        @DisplayName("should use scopes as authorities")
         void shouldUseRolesAsAuthorities() {
             final QuickcaseAuthentication authentication = userAuthentication();
 
-            final GrantedAuthority[] roles = authorities(ROLE_1, ROLE_2);
-            assertThat(authentication.getAuthorities(), containsInAnyOrder(roles));
+            assertThat(authentication.getAuthorities(), containsInAnyOrder(authorities("openid", SCOPE_2)));
         }
 
         @Test

--- a/implementation/src/main/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractor.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractor.java
@@ -35,6 +35,10 @@ public class DefaultUserInfoExtractor implements UserInfoExtractor {
                     .map(StringUtils::fromCommaSeparated)
                     .ifPresent(builder::authorities);
 
+        claimsParser.getString(claimNames.roles())
+                    .map((str) -> StringUtils.fromString(str, ","))
+                    .ifPresent(builder::roles);
+
         claimsParser.getString(claimNames.groups())
                     .map((str) -> StringUtils.fromString(str, ","))
                     .ifPresent(builder::groups);

--- a/implementation/src/test/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractorTest.java
+++ b/implementation/src/test/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractorTest.java
@@ -65,6 +65,7 @@ class DefaultUserInfoExtractorTest {
                         new SimpleGrantedAuthority("role1"),
                         new SimpleGrantedAuthority("role2")
                 )),
+                () -> assertThat(userInfo.getRoles(), containsInAnyOrder("role1", "role2")),
                 () -> assertThat(userInfo.getGroups(), containsInAnyOrder("group1", "group2")),
                 () -> assertThat(userInfo.getJurisdictions(),
                         containsInAnyOrder("org-1", "org-2"))


### PR DESCRIPTION
Roles are now exposed separately and authorities are dedicated to OAuth2 scopes.