### PR TITLE
Define precedence order for access levels and security classifications

### DIFF
--- a/api/src/main/java/app/quickcase/spring/oidc/AccessLevel.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/AccessLevel.java
@@ -1,5 +1,24 @@
 package app.quickcase.spring.oidc;
 
+import lombok.Getter;
+
+@Getter
 public enum AccessLevel {
-    ORGANISATION, GROUP, INDIVIDUAL;
+    ORGANISATION(10),
+    GROUP(20),
+    INDIVIDUAL(30);
+
+    private final int precedence;
+
+    AccessLevel(int precedence) {
+        this.precedence = precedence;
+    }
+
+    public boolean highestPrecedenceThan(AccessLevel accessLevel) {
+        return precedence > accessLevel.getPrecedence();
+    }
+
+    public boolean lowestPrecedenceThan(AccessLevel accessLevel) {
+        return precedence < accessLevel.getPrecedence();
+    }
 }

--- a/api/src/main/java/app/quickcase/spring/oidc/SecurityClassification.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/SecurityClassification.java
@@ -1,5 +1,24 @@
 package app.quickcase.spring.oidc;
 
+import lombok.Getter;
+
+@Getter
 public enum SecurityClassification {
-    PUBLIC, PRIVATE, RESTRICTED;
+    RESTRICTED(10),
+    PRIVATE(20),
+    PUBLIC(30);
+
+    private final int precedence;
+
+    SecurityClassification(int precedence) {
+        this.precedence = precedence;
+    }
+
+    public boolean highestPrecedenceThan(SecurityClassification classification) {
+        return precedence > classification.getPrecedence();
+    }
+
+    public boolean lowestPrecedenceThan(SecurityClassification classification) {
+        return precedence < classification.getPrecedence();
+    }
 }

--- a/api/src/test/java/app/quickcase/spring/oidc/AccessLevelTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/AccessLevelTest.java
@@ -1,0 +1,41 @@
+package app.quickcase.spring.oidc;
+
+import org.junit.jupiter.api.Test;
+
+import static app.quickcase.spring.oidc.AccessLevel.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class AccessLevelTest {
+
+    @Test
+    void highestPrecedenceThan() {
+        assertAll(
+                () -> assertThat(INDIVIDUAL.highestPrecedenceThan(INDIVIDUAL), is(false)),
+                () -> assertThat(INDIVIDUAL.highestPrecedenceThan(GROUP), is(true)),
+                () -> assertThat(INDIVIDUAL.highestPrecedenceThan(ORGANISATION), is(true)),
+                () -> assertThat(GROUP.highestPrecedenceThan(INDIVIDUAL), is(false)),
+                () -> assertThat(GROUP.highestPrecedenceThan(GROUP), is(false)),
+                () -> assertThat(GROUP.highestPrecedenceThan(ORGANISATION), is(true)),
+                () -> assertThat(ORGANISATION.highestPrecedenceThan(INDIVIDUAL), is(false)),
+                () -> assertThat(ORGANISATION.highestPrecedenceThan(GROUP), is(false)),
+                () -> assertThat(ORGANISATION.highestPrecedenceThan(ORGANISATION), is(false))
+        );
+    }
+
+    @Test
+    void lowestPrecedenceThan() {
+        assertAll(
+                () -> assertThat(INDIVIDUAL.lowestPrecedenceThan(INDIVIDUAL), is(false)),
+                () -> assertThat(INDIVIDUAL.lowestPrecedenceThan(GROUP), is(false)),
+                () -> assertThat(INDIVIDUAL.lowestPrecedenceThan(ORGANISATION), is(false)),
+                () -> assertThat(GROUP.lowestPrecedenceThan(INDIVIDUAL), is(true)),
+                () -> assertThat(GROUP.lowestPrecedenceThan(GROUP), is(false)),
+                () -> assertThat(GROUP.lowestPrecedenceThan(ORGANISATION), is(false)),
+                () -> assertThat(ORGANISATION.lowestPrecedenceThan(INDIVIDUAL), is(true)),
+                () -> assertThat(ORGANISATION.lowestPrecedenceThan(GROUP), is(true)),
+                () -> assertThat(ORGANISATION.lowestPrecedenceThan(ORGANISATION), is(false))
+        );
+    }
+}

--- a/api/src/test/java/app/quickcase/spring/oidc/SecurityClassificationTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/SecurityClassificationTest.java
@@ -1,0 +1,41 @@
+package app.quickcase.spring.oidc;
+
+import org.junit.jupiter.api.Test;
+
+import static app.quickcase.spring.oidc.SecurityClassification.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SecurityClassificationTest {
+
+    @Test
+    void highestPrecedenceThan() {
+        assertAll(
+                () -> assertThat(PUBLIC.highestPrecedenceThan(PUBLIC), is(false)),
+                () -> assertThat(PUBLIC.highestPrecedenceThan(PRIVATE), is(true)),
+                () -> assertThat(PUBLIC.highestPrecedenceThan(RESTRICTED), is(true)),
+                () -> assertThat(PRIVATE.highestPrecedenceThan(PUBLIC), is(false)),
+                () -> assertThat(PRIVATE.highestPrecedenceThan(PRIVATE), is(false)),
+                () -> assertThat(PRIVATE.highestPrecedenceThan(RESTRICTED), is(true)),
+                () -> assertThat(RESTRICTED.highestPrecedenceThan(PUBLIC), is(false)),
+                () -> assertThat(RESTRICTED.highestPrecedenceThan(PRIVATE), is(false)),
+                () -> assertThat(RESTRICTED.highestPrecedenceThan(RESTRICTED), is(false))
+        );
+    }
+
+    @Test
+    void lowestPrecedenceThan() {
+        assertAll(
+                () -> assertThat(PUBLIC.lowestPrecedenceThan(PUBLIC), is(false)),
+                () -> assertThat(PUBLIC.lowestPrecedenceThan(PRIVATE), is(false)),
+                () -> assertThat(PUBLIC.lowestPrecedenceThan(RESTRICTED), is(false)),
+                () -> assertThat(PRIVATE.lowestPrecedenceThan(PUBLIC), is(true)),
+                () -> assertThat(PRIVATE.lowestPrecedenceThan(PRIVATE), is(false)),
+                () -> assertThat(PRIVATE.lowestPrecedenceThan(RESTRICTED), is(false)),
+                () -> assertThat(RESTRICTED.lowestPrecedenceThan(PUBLIC), is(true)),
+                () -> assertThat(RESTRICTED.lowestPrecedenceThan(PRIVATE), is(true)),
+                () -> assertThat(RESTRICTED.lowestPrecedenceThan(RESTRICTED), is(false))
+        );
+    }
+}


### PR DESCRIPTION
Provide a programmatical way of ordering access levels and security classification to avoid duplication of ordering in consumer code