### PR TITLE
Deprecate organisation profiles

### DIFF
--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseAuthentication.java
@@ -42,6 +42,10 @@ public abstract class QuickcaseAuthentication extends AbstractAuthenticationToke
 
     public abstract Set<String> getGroups();
 
+    /**
+     * @deprecated Organisation profiles are being phased out in favour of fully role-driven authorisation.
+     */
+    @Deprecated
     public abstract OrganisationProfile getOrganisationProfile(String organisationId);
 
     public abstract Optional<UserInfo> getUserInfo();

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthentication.java
@@ -64,6 +64,10 @@ public class QuickcaseClientAuthentication extends QuickcaseAuthentication {
         return Set.of();
     }
 
+    /**
+     * @deprecated Organisation profiles are being phased out in favour of fully role-driven authorisation.
+     */
+    @Deprecated
     @Override
     public OrganisationProfile getOrganisationProfile(String organisationId) {
         return ORGANISATION_PROFILE;

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseUserAuthentication.java
@@ -59,6 +59,10 @@ public class QuickcaseUserAuthentication extends QuickcaseAuthentication {
         return userInfo.getGroups();
     }
 
+    /**
+     * @deprecated Organisation profiles are being phased out in favour of fully role-driven authorisation.
+     */
+    @Deprecated
     @Override
     public OrganisationProfile getOrganisationProfile(String organisationId) {
         return Optional.ofNullable(userInfo.getOrganisationProfiles().get(organisationId))

--- a/api/src/main/java/app/quickcase/spring/oidc/userinfo/UserInfo.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/userinfo/UserInfo.java
@@ -52,6 +52,11 @@ public class UserInfo implements Principal, UserDetails {
     @ToString.Include
     private final Set<String> groups;
     private final UserPreferences preferences;
+
+    /**
+     * @deprecated Organisation profiles are being phased out in favour of fully role-driven authorisation.
+     */
+    @Deprecated
     @NonNull
     private final Map<String, OrganisationProfile> organisationProfiles;
 


### PR DESCRIPTION
Organisation profiles are being phased out in favour of fully role-driven authorisation.