### PR TITLE
Remove deprecated `UserInfo#getJurisdictions()`

### DIFF
--- a/api/src/main/java/app/quickcase/spring/oidc/userinfo/UserInfo.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/userinfo/UserInfo.java
@@ -2,7 +2,6 @@ package app.quickcase.spring.oidc.userinfo;
 
 import java.security.Principal;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -95,17 +94,6 @@ public class UserInfo implements Principal, UserDetails {
 
     public Optional<String> getEmail() {
         return Optional.ofNullable(email);
-    }
-
-    /**
-     * @deprecated To be removed in v2.0.0, {@link #getOrganisationProfiles()} should be used instead.
-     * @return Set of organisation IDs, extracted from organisation profiles.
-     */
-    @Deprecated
-    public Set<String> getJurisdictions() {
-        return Optional.ofNullable(organisationProfiles)
-                       .map(Map::keySet)
-                       .orElse(Collections.emptySet());
     }
 
     @RequiredArgsConstructor

--- a/api/src/test/java/app/quickcase/spring/oidc/userinfo/UserInfoTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/userinfo/UserInfoTest.java
@@ -4,12 +4,11 @@ import app.quickcase.spring.oidc.organisation.OrganisationProfile;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-
 import static app.quickcase.spring.oidc.AccessLevel.GROUP;
 import static app.quickcase.spring.oidc.SecurityClassification.PRIVATE;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("UserInfo")
@@ -52,26 +51,6 @@ class UserInfoTest {
                                           .build();
 
         assertThat(userInfo.getName(), equalTo(SUBJECT));
-    }
-
-    @Test
-    @DisplayName("should return jurisdictions from organisations for backward compatibility")
-    void shouldReturnJurisdictionBackwardCompat() {
-        final UserInfo userInfo = UserInfo.builder(SUBJECT)
-                                          .organisationProfile("Juris-1", OrganisationProfile.builder().build())
-                                          .organisationProfile("Juris-2", OrganisationProfile.builder().build())
-                                          .build();
-
-        assertThat(userInfo.getJurisdictions(), hasItems("Juris-1", "Juris-2"));
-    }
-
-    @Test
-    @DisplayName("should return empty jurisdictions when no organisations")
-    void shouldReturnEmptyJurisdictionWhenNoOrganisations() {
-        final UserInfo userInfo = UserInfo.builder(SUBJECT)
-                                          .build();
-
-        assertThat(userInfo.getJurisdictions(), equalTo(Collections.EMPTY_SET));
     }
 
     @Test

--- a/implementation/src/test/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractorTest.java
+++ b/implementation/src/test/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractorTest.java
@@ -1,28 +1,25 @@
 package app.quickcase.spring.oidc.userinfo;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import app.quickcase.spring.oidc.OidcException;
 import app.quickcase.spring.oidc.claims.ClaimNamesProvider;
 import app.quickcase.spring.oidc.claims.ClaimsParser;
 import app.quickcase.spring.oidc.claims.JsonClaimsParser;
 import app.quickcase.spring.oidc.organisation.OrganisationProfile;
-import app.quickcase.spring.oidc.OidcException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static app.quickcase.spring.oidc.AccessLevel.GROUP;
 import static app.quickcase.spring.oidc.AccessLevel.ORGANISATION;
 import static app.quickcase.spring.oidc.SecurityClassification.PRIVATE;
 import static app.quickcase.spring.oidc.SecurityClassification.PUBLIC;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -66,9 +63,7 @@ class DefaultUserInfoExtractorTest {
                         new SimpleGrantedAuthority("role2")
                 )),
                 () -> assertThat(userInfo.getRoles(), containsInAnyOrder("role1", "role2")),
-                () -> assertThat(userInfo.getGroups(), containsInAnyOrder("group1", "group2")),
-                () -> assertThat(userInfo.getJurisdictions(),
-                        containsInAnyOrder("org-1", "org-2"))
+                () -> assertThat(userInfo.getGroups(), containsInAnyOrder("group1", "group2"))
         );
     }
 


### PR DESCRIPTION
Initially scheduled for removal in v2