### PR TITLE
Silence warning on missing organisation profiles

### DIFF
--- a/implementation/src/main/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractor.java
+++ b/implementation/src/main/java/app/quickcase/spring/oidc/userinfo/DefaultUserInfoExtractor.java
@@ -63,7 +63,7 @@ public class DefaultUserInfoExtractor implements UserInfoExtractor {
         return claimsParser.getObject(claimNames.organisations())
                            .map(ORG_PARSER::parse)
                            .orElseGet(() -> {
-                               log.warn("No organisation profiles extracted for subject `{}`", subject);
+                               log.debug("No organisation profiles extracted for subject `{}`", subject);
                                return Collections.emptyMap();
                            });
     }


### PR DESCRIPTION
With switch to role-driven authorisation, organisation profiles are now expected to be missing.