### PR TITLE
Combine prefixed scopes and roles as authorities

### DIFF
--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthentication.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthentication.java
@@ -3,7 +3,6 @@ package app.quickcase.spring.oidc.authentication;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import app.quickcase.spring.oidc.AccessLevel;
 import app.quickcase.spring.oidc.SecurityClassification;
@@ -23,12 +22,17 @@ public class QuickcaseClientAuthentication extends QuickcaseAuthentication {
     }
 
     private final String clientId;
+    private final Set<String> roles;
 
-    public QuickcaseClientAuthentication(String accessToken,
-                                         String clientId,
-                                         Collection<? extends GrantedAuthority> authorities) {
+    public QuickcaseClientAuthentication(
+            String accessToken,
+            String clientId,
+            Collection<? extends GrantedAuthority> authorities,
+            Set<String> roles
+    ) {
         super(authorities, accessToken);
         this.clientId = clientId;
+        this.roles = roles;
         this.setAuthenticated(true);
     }
 
@@ -54,9 +58,7 @@ public class QuickcaseClientAuthentication extends QuickcaseAuthentication {
 
     @Override
     public Set<String> getRoles() {
-        return getAuthorities().stream()
-                               .map(GrantedAuthority::getAuthority)
-                               .collect(Collectors.toSet());
+        return roles;
     }
 
     @Override

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/converter/AccessTokenAuthenticationConverter.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/converter/AccessTokenAuthenticationConverter.java
@@ -7,11 +7,11 @@ import app.quickcase.spring.oidc.authentication.QuickcaseClientAuthentication;
 import app.quickcase.spring.oidc.authentication.QuickcaseUserAuthentication;
 import app.quickcase.spring.oidc.claims.ClaimsParser;
 import app.quickcase.spring.oidc.claims.JwtClaimsParser;
+import app.quickcase.spring.oidc.userinfo.UserInfo;
 import app.quickcase.spring.oidc.userinfo.UserInfoExtractor;
-
 import org.springframework.security.oauth2.jwt.Jwt;
 
-import static app.quickcase.spring.oidc.utils.StringUtils.authorities;
+import static app.quickcase.spring.oidc.authentication.converter.QuickcaseAuthenticationConverter.authorities;
 import static app.quickcase.spring.oidc.utils.StringUtils.fromSpaceSeparated;
 
 /**
@@ -48,12 +48,13 @@ public class AccessTokenAuthenticationConverter implements QuickcaseAuthenticati
         final String accessToken = source.getTokenValue();
         final String subject = source.getSubject();
         final Set<String> scopes = fromSpaceSeparated(source.getClaimAsString("scope"));
-        return new QuickcaseClientAuthentication(accessToken, subject, authorities(scopes));
+        return new QuickcaseClientAuthentication(accessToken, subject, authorities(scopes), scopes);
     }
 
     private QuickcaseAuthentication userAuthentication(Jwt source) {
         final ClaimsParser claims = new JwtClaimsParser(source.getClaims());
         final Set<String> scopes = fromSpaceSeparated(source.getClaimAsString("scope"));
-        return new QuickcaseUserAuthentication(source.getTokenValue(), authorities(scopes), userInfoExtractor.extract(claims));
+        final UserInfo userInfo = userInfoExtractor.extract(claims);
+        return new QuickcaseUserAuthentication(source.getTokenValue(), authorities(scopes, userInfo.getRoles()), userInfo);
     }
 }

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/converter/QuickcaseAuthenticationConverter.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/converter/QuickcaseAuthenticationConverter.java
@@ -1,9 +1,35 @@
 package app.quickcase.spring.oidc.authentication.converter;
 
-import app.quickcase.spring.oidc.authentication.QuickcaseAuthentication;
+import java.util.Set;
+import java.util.stream.Stream;
 
+import app.quickcase.spring.oidc.authentication.QuickcaseAuthentication;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 
+import static java.util.stream.Collectors.toSet;
+
 public interface QuickcaseAuthenticationConverter extends Converter<Jwt, QuickcaseAuthentication> {
+    static String prefixScope(String scope) {
+        return "SCOPE_" + scope;
+    }
+
+    static String prefixRole(String role) {
+        return "ROLE_" + role;
+    }
+
+    static Set<GrantedAuthority> authorities(Set<String> scopes) {
+        return authorities(scopes, Set.of());
+    }
+
+    static Set<GrantedAuthority> authorities(Set<String> scopes, Set<String> roles) {
+        return Stream.concat(
+                             scopes.stream().map(QuickcaseAuthenticationConverter::prefixScope),
+                             roles.stream().map(QuickcaseAuthenticationConverter::prefixRole)
+                     )
+                     .map(SimpleGrantedAuthority::new)
+                     .collect(toSet());
+    }
 }

--- a/api/src/main/java/app/quickcase/spring/oidc/authentication/converter/UserInfoAuthenticationConverter.java
+++ b/api/src/main/java/app/quickcase/spring/oidc/authentication/converter/UserInfoAuthenticationConverter.java
@@ -7,10 +7,9 @@ import app.quickcase.spring.oidc.authentication.QuickcaseClientAuthentication;
 import app.quickcase.spring.oidc.authentication.QuickcaseUserAuthentication;
 import app.quickcase.spring.oidc.userinfo.UserInfo;
 import app.quickcase.spring.oidc.userinfo.UserInfoService;
-
 import org.springframework.security.oauth2.jwt.Jwt;
 
-import static app.quickcase.spring.oidc.utils.StringUtils.authorities;
+import static app.quickcase.spring.oidc.authentication.converter.QuickcaseAuthenticationConverter.authorities;
 import static app.quickcase.spring.oidc.utils.StringUtils.fromSpaceSeparated;
 
 public class UserInfoAuthenticationConverter implements QuickcaseAuthenticationConverter {
@@ -43,7 +42,7 @@ public class UserInfoAuthenticationConverter implements QuickcaseAuthenticationC
         final String accessToken = source.getTokenValue();
         final String subject = source.getSubject();
         final Set<String> scopes = fromSpaceSeparated(source.getClaimAsString("scope"));
-        return new QuickcaseClientAuthentication(accessToken, subject, authorities(scopes));
+        return new QuickcaseClientAuthentication(accessToken, subject, authorities(scopes), scopes);
     }
 
     private QuickcaseUserAuthentication userAuthentication(Jwt source) {
@@ -52,6 +51,6 @@ public class UserInfoAuthenticationConverter implements QuickcaseAuthenticationC
         final Set<String> scopes = fromSpaceSeparated(source.getClaimAsString("scope"));
         final UserInfo userInfo = userInfoService.loadUserInfo(subject, accessToken);
 
-        return new QuickcaseUserAuthentication(accessToken, authorities(scopes), userInfo);
+        return new QuickcaseUserAuthentication(accessToken, authorities(scopes, userInfo.getRoles()), userInfo);
     }
 }

--- a/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthenticationTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/authentication/QuickcaseClientAuthenticationTest.java
@@ -111,7 +111,8 @@ class QuickcaseClientAuthenticationTest {
     }
 
     private QuickcaseAuthentication clientAuthentication() {
-        final Set<GrantedAuthority> authorities = StringUtils.authorities("ROLE-1", "ROLE-2");
-        return new QuickcaseClientAuthentication(ACCESS_TOKEN, CLIENT_ID, authorities);
+        final Set<String> scopes = Set.of("ROLE-1", "ROLE-2");
+        final Set<GrantedAuthority> authorities = StringUtils.authorities(scopes);
+        return new QuickcaseClientAuthentication(ACCESS_TOKEN, CLIENT_ID, authorities, scopes);
     }
 }

--- a/api/src/test/java/app/quickcase/spring/oidc/authentication/converter/UserInfoAuthenticationConverterTest.java
+++ b/api/src/test/java/app/quickcase/spring/oidc/authentication/converter/UserInfoAuthenticationConverterTest.java
@@ -48,7 +48,7 @@ class UserInfoAuthenticationConverterTest {
         userInfoServiceStub = (sub, token) -> UserInfo.builder(sub)
                                                       .name(USER_NAME)
                                                       .email(USER_EMAIL)
-                                                      .authorities(ROLE_1, ROLE_2)
+                                                      .roles(ROLE_1, ROLE_2)
                                                       .organisationProfile("org-a", orgA)
                                                       .build();
 
@@ -79,12 +79,22 @@ class UserInfoAuthenticationConverterTest {
         }
 
         @Test
-        @DisplayName("should use scopes as authorities")
+        @DisplayName("should use scopes as prefixed authorities")
         void shouldUseScopesAsAuthorities() {
             final QuickcaseAuthentication authentication = clientAuthentication();
 
-            final GrantedAuthority[] scopes = authorities(SCOPE_1, SCOPE_2);
-            assertThat(authentication.getAuthorities(), containsInAnyOrder(scopes));
+            assertThat(authentication.getAuthorities(), containsInAnyOrder(authorities(
+                    "SCOPE_" + SCOPE_1,
+                    "SCOPE_" + SCOPE_2
+            )));
+        }
+
+        @Test
+        @DisplayName("should use scopes as roles")
+        void shouldUseScopesAsRoles() {
+            final QuickcaseAuthentication authentication = clientAuthentication();
+
+            assertThat(authentication.getRoles(), containsInAnyOrder(SCOPE_1, SCOPE_2));
         }
 
         @Test
@@ -158,11 +168,24 @@ class UserInfoAuthenticationConverterTest {
         }
 
         @Test
-        @DisplayName("should use scopes as authorities")
+        @DisplayName("should combine prefixed scopes and roles as authorities")
         void shouldUseRolesAsAuthorities() {
             final QuickcaseAuthentication authentication = userAuthentication();
 
-            assertThat(authentication.getAuthorities(), containsInAnyOrder(authorities("openid", SCOPE_2)));
+            assertThat(authentication.getAuthorities(), containsInAnyOrder(authorities(
+                    "SCOPE_openid",
+                    "SCOPE_" + SCOPE_2,
+                    "ROLE_" + ROLE_1,
+                    "ROLE_" + ROLE_2
+            )));
+        }
+
+        @Test
+        @DisplayName("should expose user roles")
+        void shouldUseScopesAsRoles() {
+            final QuickcaseAuthentication authentication = userAuthentication();
+
+            assertThat(authentication.getRoles(), containsInAnyOrder(ROLE_1, ROLE_2));
         }
 
         @Test


### PR DESCRIPTION
Removal of roles from authorities in 081b5bb was a mistake, this change reverts authorities to being the concatenation of both scopes and roles. However, it is not correct for roles and scopes to not distinguishable in authorities. Spring addresses this by prefixing scopes with `SCOPE_` and roles with `ROLE_`. This change follows this practice.